### PR TITLE
Reduce allocations with cache

### DIFF
--- a/src/MosekTools.jl
+++ b/src/MosekTools.jl
@@ -59,6 +59,29 @@ struct MatrixIndex
     end
 end
 
+# Used to avoid reallocation of temporary vectors
+struct Cache
+    # Used in `split_scalar_matrix`
+    cols::Vector{Int32}
+    values::Vector{Float64}
+    sd_row::Vector{Int32}
+    sd_col::Vector{Int32}
+    sd_coef::Vector{Float64}
+    ids::Vector{Int64}
+    weights::Vector{Float64}
+    function Cache()
+        return new(
+            Int32[],
+            Float64[],
+            Int32[],
+            Int32[],
+            Float64[],
+            Int64[],
+            Float64[],
+        )
+    end
+end
+
 """
     Optimizer <: MOI.AbstractOptimizer
 
@@ -141,6 +164,8 @@ mutable struct Optimizer  <: MOI.AbstractOptimizer
     """
     has_objective :: Bool
 
+    cache :: Cache
+
     fallback :: Union{String, Nothing}
 
     function Optimizer(; kws...)
@@ -164,6 +189,7 @@ mutable struct Optimizer  <: MOI.AbstractOptimizer
             MosekSolution[],
             true, # feasibility_sense
             false, # has_objective
+            Cache(),
             nothing,
         )
         Mosek.appendrzerodomain(optimizer.task,0)

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -23,10 +23,10 @@ MOI.supports(::Optimizer,::MOI.ObjectiveSense) = true
 
 function MOI.set(m::Optimizer, ::MOI.ObjectiveFunction,
                  func::MOI.ScalarAffineFunction{Float64})
-    cols, values = split_scalar_matrix(m, MOI.Utilities.canonical(func).terms,
+    split_scalar_matrix(m, MOI.Utilities.canonical(func).terms,
                                        (j, ids, coefs) -> putbarcj(m.task, j, ids, coefs))
     c = zeros(Float64, getnumvar(m.task))
-    for (col, val) in zip(cols, values)
+    for (col, val) in zip(m.cache.cols, m.cache.values)
         c[col] += val
     end
     putclist(m.task, convert(Vector{Int32}, 1:length(c)), c)


### PR DESCRIPTION
I saw these allocations seem non-negligeable in `@profview_allocs` but this would need proper benchmarking. There is an extra allocation done in Mosek.jl because it allocates to decrease by `1` the indices, we might want to directly create 0-based index and directly call the underlying function to bypass this.