### PR TITLE
Drop Julia v1.10 from CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - version: '1.6'
-            os: ubuntu-latest
-            arch: x64
-          - version: '1.10'
-            os: ubuntu-latest
-            arch: x64
-          - version: '1'
-            os: ubuntu-latest
-            arch: x64
+        version: ['1.6', '1']
+        os: [ubuntu-latest]
+        arch: [x64]
     steps:
       - name: Install xmllint
         run: sudo apt-get install -y curl


### PR DESCRIPTION
We don't need to test 1.6, 1.10 and 1.X. It can be 1.6 and 1.X until we bump the minimum version. This should reduce the number of API calls we're making to the Mosek server.