### PR TITLE
Fix MOI.VariableBasisStatus

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -423,7 +423,7 @@ function MOI.get(m::Optimizer, attr::MOI.VariableBasisStatus, col::ColumnIndex)
     elseif status == Mosek.MSK_SK_FIX       # (5)
         return MOI.NONBASIC
     end
-    @assert x == Mosek.MSK_SK_INF       # (6)
+    @assert status == Mosek.MSK_SK_INF      # (6)
     msg = "The constraint or variable is infeasible in the bounds"
     return throw(MOI.GetAttributeNotAllowed(attr, msg))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -303,14 +303,13 @@ end
 
 function test_variable_basis_status()
     model = Mosek.Optimizer()
-    x, cx = MOI.add_constrained_variables(
-        model,
-        MOI.PositiveSemidefiniteConeTriangle(2),
-    )
+    set = MOI.PositiveSemidefiniteConeTriangle(2)
+    x, _ = MOI.add_constrained_variables(model, set)
     attr = MOI.VariableBasisStatus()
     index = MosekTools.mosek_index(model, x[1])
-    err = ErrorException("$attr not supported for PSD variable $index")
-    @test_throws err MOI.get(model, attr, index)
+    msg = "$attr not supported for PSD variable $index"
+    err = MOI.GetAttributeNotAllowed(attr, msg)
+    @test_throws err MOI.get(model, attr, x[1])
     return
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -309,7 +309,7 @@ function test_variable_basis_status()
     index = MosekTools.mosek_index(model, x[1])
     msg = "$attr not supported for PSD variable $index"
     err = MOI.GetAttributeNotAllowed(attr, msg)
-    @test_throws err MOI.get(model, attr, x[1])
+    @test_throws err MOI.get(model, attr, index)
     return
 end
 


### PR DESCRIPTION
Obviously never used and never tested. Should be `MOI.BASIC` not `BASIC`!