### PR TITLE
Add support for MOI.ConstraintBasisStatus

### DIFF
--- a/src/MosekTools.jl
+++ b/src/MosekTools.jl
@@ -461,12 +461,12 @@ function MOI.optimize!(m::Optimizer)
             sol.solsta == Mosek.MSK_SOL_STA_INTEGER_OPTIMAL ||
             sol.solsta == Mosek.MSK_SOL_STA_OPTIMAL
         if sol.whichsol == Mosek.MSK_SOL_ITG
-            return (3, solsta_priority)
+            return (solsta_priority, 3)
         elseif sol.whichsol == Mosek.MSK_SOL_BAS
-            return (2, solsta_priority)
+            return (solsta_priority, 2)
         else
             @assert sol.whichsol == Mosek.MSK_SOL_ITR
-            return (1, solsta_priority)
+            return (solsta_priority, 1)
         end
     end
     # Sort solutions largest priority to smallest

--- a/src/MosekTools.jl
+++ b/src/MosekTools.jl
@@ -384,21 +384,21 @@ function MOI.optimize!(m::Optimizer)
         push!(
             m.solutions,
             MosekSolution(
-                Mosek.MSK_SOL_ITR,
-                Mosek.getsolsta(m.task, Mosek.MSK_SOL_ITR),
-                Mosek.getprosta(m.task, Mosek.MSK_SOL_ITR),
-                Mosek.getskx(m.task, Mosek.MSK_SOL_ITR),
-                Mosek.getxx(m.task, Mosek.MSK_SOL_ITR),
-                matrix_solution(m, Mosek.MSK_SOL_ITR),
-                Mosek.getslx(m.task, Mosek.MSK_SOL_ITR),
-                Mosek.getsux(m.task, Mosek.MSK_SOL_ITR),
-                Mosek.getsnx(m.task, Mosek.MSK_SOL_ITR),
-                Mosek.getaccdotys(m.task, Mosek.MSK_SOL_ITR),
-                Mosek.getskc(m.task, Mosek.MSK_SOL_ITR),
-                Mosek.getxc(m.task, Mosek.MSK_SOL_ITR),
-                Mosek.getslc(m.task, Mosek.MSK_SOL_ITR),
-                Mosek.getsuc(m.task, Mosek.MSK_SOL_ITR),
-                Mosek.gety(m.task, Mosek.MSK_SOL_ITR),
+                Mosek.MSK_SOL_ITR,                             # whichsol
+                Mosek.getsolsta(m.task, Mosek.MSK_SOL_ITR),    # solsta
+                Mosek.getprosta(m.task, Mosek.MSK_SOL_ITR),    # prosta
+                Mosek.getskx(m.task, Mosek.MSK_SOL_ITR),       # xxstatus
+                Mosek.getxx(m.task, Mosek.MSK_SOL_ITR),        # xx
+                matrix_solution(m, Mosek.MSK_SOL_ITR),         # barxk
+                Mosek.getslx(m.task, Mosek.MSK_SOL_ITR),       # slx
+                Mosek.getsux(m.task, Mosek.MSK_SOL_ITR),       # sux
+                Mosek.getsnx(m.task, Mosek.MSK_SOL_ITR),       # snx
+                Mosek.getaccdotys(m.task, Mosek.MSK_SOL_ITR),  # doty
+                Mosek.getskc(m.task, Mosek.MSK_SOL_ITR),       # cstatus
+                Mosek.getxc(m.task, Mosek.MSK_SOL_ITR),        # xc
+                Mosek.getslc(m.task, Mosek.MSK_SOL_ITR),       # slc
+                Mosek.getsuc(m.task, Mosek.MSK_SOL_ITR),       # suc
+                Mosek.gety(m.task, Mosek.MSK_SOL_ITR),         # y
             ),
         )
     end
@@ -406,22 +406,24 @@ function MOI.optimize!(m::Optimizer)
         push!(
             m.solutions,
             MosekSolution(
-                Mosek.MSK_SOL_ITG,
-                Mosek.getsolsta(m.task, Mosek.MSK_SOL_ITG),
-                Mosek.getprosta(m.task, Mosek.MSK_SOL_ITG),
-                Mosek.getskx(m.task, Mosek.MSK_SOL_ITG),
-                Mosek.getxx(m.task, Mosek.MSK_SOL_ITG),
+                Mosek.MSK_SOL_ITG,                             # whichsol
+                Mosek.getsolsta(m.task, Mosek.MSK_SOL_ITG),    # solsta
+                Mosek.getprosta(m.task, Mosek.MSK_SOL_ITG),    # prosta
+                Mosek.getskx(m.task, Mosek.MSK_SOL_ITG),       # xxstatus
+                Mosek.getxx(m.task, Mosek.MSK_SOL_ITG),        # xx
+                # MSK_SOL_ITG means integer solution. It cannot have PSD
+                # matrices, and it does not have dual variables.
                 # See https://github.com/jump-dev/MosekTools.jl/issues/71
-                Float64[], #matrix_solution(m, Mosek.MSK_SOL_ITG),
-                Float64[],
-                Float64[],
-                Float64[],
-                Float64[],
-                Mosek.getskc(m.task, Mosek.MSK_SOL_ITG),
-                Mosek.getxc(m.task, Mosek.MSK_SOL_ITG),
-                Float64[],
-                Float64[],
-                Float64[],
+                Float64[],                                     # barxk
+                Float64[],                                     # slx
+                Float64[],                                     # sux
+                Float64[],                                     # snx
+                Float64[],                                     # doty
+                Mosek.getskc(m.task, Mosek.MSK_SOL_ITG),       # cstatus
+                Mosek.getxc(m.task, Mosek.MSK_SOL_ITG),        # xc
+                Float64[],                                     # slc
+                Float64[],                                     # suc
+                Float64[],                                     # y
             ),
         )
     end
@@ -429,32 +431,46 @@ function MOI.optimize!(m::Optimizer)
         push!(
             m.solutions,
             MosekSolution(
-                Mosek.MSK_SOL_BAS,
-                Mosek.getsolsta(m.task, Mosek.MSK_SOL_BAS),
-                Mosek.getprosta(m.task, Mosek.MSK_SOL_BAS),
-                Mosek.getskx(m.task, Mosek.MSK_SOL_BAS),
-                Mosek.getxx(m.task, Mosek.MSK_SOL_BAS),
+                Mosek.MSK_SOL_BAS,                              # whichsol
+                Mosek.getsolsta(m.task, Mosek.MSK_SOL_BAS),     # solsta
+                Mosek.getprosta(m.task, Mosek.MSK_SOL_BAS),     # prosta
+                Mosek.getskx(m.task, Mosek.MSK_SOL_BAS),        # xxstatus
+                Mosek.getxx(m.task, Mosek.MSK_SOL_BAS),         # xx
+                # MSK_SOL_BAS means a basic solution. It cannot have PSD
+                # matrices.
                 # See https://github.com/jump-dev/MosekTools.jl/issues/71
-                Float64[], #matrix_solution(m, Mosek.MSK_SOL_BAS),
-                Mosek.getslx(m.task, Mosek.MSK_SOL_BAS),
-                Mosek.getsux(m.task, Mosek.MSK_SOL_BAS),
-                Float64[],
-                Float64[],
-                Mosek.getskc(m.task, Mosek.MSK_SOL_BAS),
-                Mosek.getxc(m.task, Mosek.MSK_SOL_BAS),
-                Mosek.getslc(m.task, Mosek.MSK_SOL_BAS),
-                Mosek.getsuc(m.task, Mosek.MSK_SOL_BAS),
-                Mosek.gety(m.task, Mosek.MSK_SOL_BAS),
+                Float64[],                                      # barxk
+                Mosek.getslx(m.task, Mosek.MSK_SOL_BAS),        # slx
+                Mosek.getsux(m.task, Mosek.MSK_SOL_BAS),        # sux
+                Float64[],                                      # snx
+                Float64[],                                      # doty
+                Mosek.getskc(m.task, Mosek.MSK_SOL_BAS),        # cstatus
+                Mosek.getxc(m.task, Mosek.MSK_SOL_BAS),         # xc
+                Mosek.getslc(m.task, Mosek.MSK_SOL_BAS),        # slc
+                Mosek.getsuc(m.task, Mosek.MSK_SOL_BAS),        # suc
+                Mosek.gety(m.task, Mosek.MSK_SOL_BAS),          # y
             ),
         )
     end
-    # We need to sort the solutions, so that an optimal one is first (if it exists).
-    sort!(
-        m.solutions;
-        by = x -> x.solsta in
-        [Mosek.MSK_SOL_STA_OPTIMAL, Mosek.MSK_SOL_STA_INTEGER_OPTIMAL],
-        rev = true,
-    )
+    # We need to sort the solutions, so that an optimal one is first (if it
+    # exists). The priority is:
+    #  1. MSK_SOL_STA_INTEGER_OPTIMAL or MSK_SOL_STA_OPTIMAL
+    #  2. MSK_SOL_ITG, MSK_SOL_BAS, MSK_SOL_ITR
+    function solution_priority(sol)
+        solsta_priority =
+            sol.solsta == Mosek.MSK_SOL_STA_INTEGER_OPTIMAL ||
+            sol.solsta == Mosek.MSK_SOL_STA_OPTIMAL
+        if sol.whichsol == Mosek.MSK_SOL_ITG
+            return (3, solsta_priority)
+        elseif sol.whichsol == Mosek.MSK_SOL_BAS
+            return (2, solsta_priority)
+        else
+            @assert sol.whichsol == Mosek.MSK_SOL_ITR
+            return (1, solsta_priority)
+        end
+    end
+    # Sort solutions largest priority to smallest
+    sort!(m.solutions; by = solution_priority, rev = true)
     return
 end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -347,6 +347,21 @@ function MOI.get(
     return MOI.get(m, attr, mosek_index(m, vi))
 end
 
+#### ConstraintBasisStatus
+
+function MOI.get(
+    m::Optimizer,
+    attr::MOI.ConstraintBasisStatus,
+    ci::MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}},
+)
+    MOI.check_result_index_bounds(m, attr)
+    cid = ref2id(ci)
+    subi = getindex(m.c_block, cid)
+    # FIXME(odow): MOI assumes that thhe first solution is basic. But often
+    # Mosek's first solution is an interior point, and the second is basic.
+    return m.solutions[attr.result_index].cstatus[subi]
+end
+
 #### Constraint solution values
 
 function MOI.get(

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -372,8 +372,6 @@ function MOI.get(
     MOI.check_result_index_bounds(m, attr)
     cid = ref2id(ci)
     subi = getindex(m.c_block, cid)
-    # FIXME(odow): MOI assumes that thhe first solution is basic. But often
-    # Mosek's first solution is an interior point, and the second is basic.
     status = m.solutions[attr.result_index].cstatus[subi]
     return _adjust_nonbasic(_basis_status_code(status, attr), S)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -351,11 +351,8 @@ function test_moi_test_runtests_Mosek()
         Float64;
         atol = 1e-3,
         rtol = 1e-3,
-        exclude = Any[
-            MOI.ConstraintBasisStatus,
-            # TODO remove `MOI.delete` once it is implemented for ACC
-            MOI.delete,
-        ],
+        # TODO remove `MOI.delete` once it is implemented for ACC
+        exclude = Any[MOI.delete],
     )
     MOI.Test.runtests(
         MosekOptimizerWithFallback(),
@@ -376,11 +373,8 @@ function test_moi_test_runtests_Bridge_Mosek()
         Float64;
         atol = 1e-3,
         rtol = 1e-3,
-        exclude = Any[
-            MOI.ConstraintBasisStatus,
-            # TODO remove `MOI.delete` once it is implemented for ACC
-            MOI.delete,
-        ],
+        # TODO remove `MOI.delete` once it is implemented for ACC
+        exclude = Any[MOI.delete],
     )
     MOI.Test.runtests(
         model,
@@ -414,11 +408,8 @@ function test_moi_test_runtests_Bridge_Cache_Mosek()
         Float64;
         atol = 1e-3,
         rtol = 1e-3,
-        exclude = Any[
-            MOI.ConstraintBasisStatus,
-            # TODO remove `MOI.delete` once it is implemented for ACC
-            MOI.delete,
-        ],
+        # TODO remove `MOI.delete` once it is implemented for ACC
+        exclude = Any[MOI.delete],
     )
     # Evaluated: MathOptInterface.OTHER_ERROR in (MathOptInterface.OPTIMAL, MathOptInterface.INVALID_MODEL)
     MOI.Test.runtests(model, config; exclude = ["test_conic_empty_matrix"])
@@ -439,12 +430,8 @@ function test_more_SDP_tests_by_forced_bridging()
         Float64;
         atol = 1e-3,
         rtol = 1e-3,
-        exclude = Any[
-            MOI.ConstraintName,
-            MOI.ConstraintBasisStatus,
-            # TODO remove `MOI.delete` once it is implemented for ACC
-            MOI.delete,
-        ],
+        # TODO remove `MOI.delete` once it is implemented for ACC
+        exclude = Any[MOI.delete],
     )
     MOI.Test.runtests(model, config; include = ["conic_SecondOrderCone"])
     return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -452,7 +452,7 @@ function test_VariableBasisStatus()
     @test MOI.get(model, attr, x_fix) == MOI.NONBASIC
     @test MOI.get(model, attr, x_supbas) == MOI.SUPER_BASIC
     # Mosek reports SUPER_BASIC?
-    @test MOI.get(model, attr, x_bas) in (MOI.BASIC, MOI.SUPER_BASIC)
+    @test MOI.get(model, attr, x_bas) == MOI.BASIC
     MOI.add_constraint(model, x_low, MOI.LessThan(-1.0))
     MOI.optimize!(model)
     msg = "The constraint or variable is infeasible in the bounds"


### PR DESCRIPTION
I think I need to fix #72 first so we can make the basic solution `result_index = 1` if one exists.

This is also the cause of 
https://github.com/jump-dev/MosekTools.jl/blob/0287ab49ab7d2fc3c3aa6389220e44fd002da095/test/runtests.jl#L467-L468

Closes #72 