### PR TITLE
Fix MOI.SimplexIterations and MOI.BarrierIterations

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -104,20 +104,14 @@ end
 #### Solver/Solution information
 
 function MOI.get(m::Optimizer, ::MOI.SimplexIterations)::Int64
-    miosimiter = Mosek.getlintinf(m.task, Mosek.MSK_LIINF_MIO_SIMPLEX_ITER)
-    if miosimiter > 0
-        return miosimiter
-    end
-    return Mosek.getintinf(m.task, Mosek.MSK_IINF_SIM_PRIMAL_ITER) +
+    return Mosek.getlintinf(m.task, Mosek.MSK_LIINF_MIO_SIMPLEX_ITER) +
+           Mosek.getintinf(m.task, Mosek.MSK_IINF_SIM_PRIMAL_ITER) +
            Mosek.getintinf(m.task, Mosek.MSK_IINF_SIM_DUAL_ITER)
 end
 
 function MOI.get(m::Optimizer, ::MOI.BarrierIterations)::Int64
-    miosimiter = Mosek.getlintinf(m.task, Mosek.MSK_LIINF_MIO_INTPNT_ITER)
-    if miosimiter > 0
-        return miosimiter
-    end
-    return Mosek.getintinf(m.task, Mosek.MSK_IINF_INTPNT_ITER)
+    return Mosek.getlintinf(m.task, Mosek.MSK_LIINF_MIO_INTPNT_ITER) +
+           Mosek.getintinf(m.task, Mosek.MSK_IINF_INTPNT_ITER)
 end
 
 function MOI.get(m::Optimizer, ::MOI.NodeCount)::Int64

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -642,9 +642,8 @@ function test_variable_primal_start()
     return
 end
 
-function test_simplex_iterations()
+function test_raw_status_string()
     model = MosekOptimizerWithFallback()
-    MOI.set(model, MOI.Silent(), false)
     @test MOI.get(model, MOI.RawStatusString()) == "MOI.OPTIMIZE_NOT_CALLED"
     MOI.set(
         model,


### PR DESCRIPTION
We're arguably interested in the total number of iterations across all subsolvers.